### PR TITLE
Improvement to local Workbench runtime

### DIFF
--- a/WorkbenchProject/pom.xml
+++ b/WorkbenchProject/pom.xml
@@ -16,47 +16,44 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <build>
+        
         <plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.6.2</version>
-				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
-				</configuration>
-			</plugin>
             <plugin>
-                <!-- Build an executable JAR -->
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <version>3.0.2</version>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.6.2</version>
                 <configuration>
-                    <archive>
-                        <manifest>
-                            <addClasspath>true</addClasspath>
-                            <classpathPrefix>lib/</classpathPrefix>
-                            <mainClass>edu.uwb.braingrid.workbenchdashboard.WorkbenchDashboard</mainClass>
-                        </manifest>
-                    </archive>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <version>2.1</version>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.4</version>
                 <executions>
                     <execution>
-                        <id>copy-dependencies</id>
-                        <phase>package</phase>
                         <goals>
-                            <goal>copy-dependencies</goal>
+                            <goal>shade</goal>
                         </goals>
                         <configuration>
-                            <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                            <overWriteReleases>false</overWriteReleases>
-                            <overWriteSnapshots>false</overWriteSnapshots>
-                            <overWriteIfNewer>true</overWriteIfNewer>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
+                            <transformers>
+                                <transformer implementation=
+                      "org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>edu.uwb.braingrid.workbenchdashboard.WorkbenchDashboard</mainClass>
+                                </transformer>
+                            </transformers>
                         </configuration>
                     </execution>
                 </executions>
@@ -67,11 +64,6 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.19.1</version>
                 <dependencies>
-                 <!--   <dependency>
-                        <groupId>org.junit.platform</groupId>
-                        <artifactId>junit-platform-surefire-provider</artifactId>
-                        <version>1.1.0</version>
-                    </dependency> -->
                     <dependency>
                         <groupId>org.junit.jupiter</groupId>
                         <artifactId>junit-jupiter-engine</artifactId>

--- a/WorkbenchProject/src/main/java/edu/uwb/braingrid/workbench/provvisualizer/controller/ProVisCtrl.java
+++ b/WorkbenchProject/src/main/java/edu/uwb/braingrid/workbench/provvisualizer/controller/ProVisCtrl.java
@@ -530,9 +530,20 @@ public class ProVisCtrl {
 
 		while (iter.hasNext()) {
 			stmt = iter.nextStatement();
-			if (stmt.getSubject().toString().contains("local:"))
-				continue;
-			String predicateStr = stmt.getPredicate().toString();
+
+			if (stmt.getSubject().toString().contains("local:")) {
+                            System.out.println("Continuing on stmt subject: " + stmt.getSubject().toString());
+                            // continue;
+                        }
+                        String predicateStr = stmt.getPredicate().toString();
+
+                        System.out.println("iterator stmt subject: " + stmt.getSubject().toString());
+                        System.out.println("\t\tobject: " + stmt.getObject().toString());
+                        System.out.println("\t\tpredicate: " + stmt.getObject().toString());
+                        
+                        // TODO: Figure out why .xml files referenced in .ttl files have invalid paths. (Default to ~/<filename>.xml instead of their actual location in the working directory.)
+                        // TODO: Figure out why output files aren't included in the provenance data
+
 			if (predicateStr.equals(ProvUtility.RDF_TYPE)) {
 				String subjectStr = stmt.getSubject().toString();
 				String objectStr = stmt.getObject().toString();

--- a/WorkbenchProject/src/main/java/edu/uwb/braingrid/workbenchdashboard/WorkbenchDashboard.java
+++ b/WorkbenchProject/src/main/java/edu/uwb/braingrid/workbenchdashboard/WorkbenchDashboard.java
@@ -124,11 +124,12 @@ public class WorkbenchDashboard extends Application {
 			
 		});
 
-		URL is = Resources.getResource("braingrid/color-logo.png");
-		Image image = new Image(is.getFile());
+		// URL is = Resources.getResource("braingrid/color-logo.png");
+                // System.out.println(is.getPath());
+		// Image image = new Image(is.getFile());
 		primaryStage.setTitle("BrainGrid Workbench");
 
-		primaryStage.getIcons().add(image);
+		// primaryStage.getIcons().add(image);
 		
 		primaryStage.setScene(scene);
 		primaryStage.setMaximized(true);


### PR DESCRIPTION
1. Use maven-shade to enable bundled .jar file including deps
2. Fix ability to run locally by not skipping `local:` items in the .ttl file
3. Remove BrainGrid icon load into GUI that prevented startup in the IDE context (for unknown reasons)