### PR TITLE
Added implementation details about nodes spacing out in ProVis to Workbench docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -59,3 +59,13 @@ The idea behind the BrainGrid Workbench is to develop an application to ease cre
        4.2.1. Apache Maven
 
        4.2.2. Checkstyle
+
+    4.3. Implementation Details
+
+        4.3.1. ProVis Node Spacing
+
+            4.3.1.1. Current Behavior
+
+            4.3.1.2. Expected Behavior
+
+            4.3.1.3. Jupyter Notebook


### PR DESCRIPTION
In this branch are the changes I made to the documentation, documenting the implementation details of how ProVis spaces out nodes. I pretty much copy-pasted the issue from GitHub, and I put *Implementation Details* as a subheading under *Internal Development*. I wasn't sure whether to do this or have it as an entirely separate page; your feedback would be appreciated.

The only other bit I was thinking of was whether I should add a bit at the beginning, briefly explaining how the force-directed graph works (the forces it calculates between the nodes and the formulas involved).

To view it, you can obviously view the actual files, or, if you are using Visual Studio Code, you can install the "Markdown All in One" extension from Yu Zhang, right click on the markdown file you wish to view, click on "Open Preview" and you should be able to view the parsed markdown. I couldn't find an easy way to just install MkDocs and serve it locally, since this is using some external theme from Jekyll.

Any other feedback is welcome!